### PR TITLE
Adapt to Docker compose v2 bin

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -16,7 +16,7 @@ You also need to set the DOCKER_HOST_SUFFIX env var in your shell
 
 ```shell
 cp .env.dist .env
-docker-compose up -d
+docker compose up -d
 ```
 
 Github Container Registry :


### PR DESCRIPTION
Sur le `docker-compose up -d`, j'ai un

> ERROR: Invalid interpolation format for "mkcert" option in service "services": "${CA_STORE:-/usr/local/share/ca-certificates}:/usr/local/share/ca-certificates"

`docker compose up -d` résous ce petit soucis