### PR TITLE
fix(adminer): use PHP instead of cURL for container healthcheck

### DIFF
--- a/database/adminer/adminer.yml
+++ b/database/adminer/adminer.yml
@@ -10,7 +10,7 @@ services:
       public:
       private:
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080"]
+      test: ["CMD", "php", "-r", "@file_get_contents('http://localhost:8080') or exit(1);"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
cURL isn't available on this Docker image, unlike PHP