### PR TITLE
chore(maildev): remove redundant `--hide-extensions STARTTLS` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.4.1](https://github.com/le-phare/docker-stack/compare/v2.4.0...v2.4.1) (2024-07-31)
+
+### Miscellaneous Chores
+
+* **maildev:** remove redundant `--hide-extensions STARTTLS` option ([todo](https://github.com/le-phare/docker-stack/commit/todo))
+
 ## [2.4.0](https://github.com/le-phare/docker-stack/compare/v2.3.2...v2.4.0) (2024-07-19)
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     networks:
       public:
       private:
-    command: bin/maildev --web 80 --smtp 25 --outgoing-host smtp-relay.gmail.com --outgoing-secure --hide-extensions STARTTLS
+    command: bin/maildev --web 80 --smtp 25 --outgoing-host smtp-relay.gmail.com --outgoing-secure
     labels:
       caddy: maildev.${DOCKER_HOST_SUFFIX:-local}
       caddy.tls: internal


### PR DESCRIPTION
This is the default option since https://github.com/maildev/maildev/pull/276