### PR TITLE
fix(adminer): databases pre-login plugin: set required $_SESSION data

### DIFF
--- a/database/adminer/plugins/le-phare-pre-login-to-databases.php
+++ b/database/adminer/plugins/le-phare-pre-login-to-databases.php
@@ -1,23 +1,23 @@
 <?php
-use function Adminer\set_password;
 
-/** Pre-login to Le Phare database servers */
+/**
+ * Pre-login to Le Phare database servers.
+ */
 class LePharePluginPreLoginToDatabases
 {
+  const array MYSQL_HOSTS = ['mysql_5', 'mariadb_10'];
+  const array POSTGRESQL_HOSTS = ['pgsql_9', 'pgsql_10', 'pgsql_11', 'pgsql_12', 'pgsql_13', 'pgsql_14', 'pgsql_15', 'pgsql_16', 'pgsql_17',];
+
   function __construct()
   {
-    set_password('server', 'mysql_5', 'root', 'root');
+    foreach (self::MYSQL_HOSTS as $MYSQL_HOST) {
+      \Adminer\set_password('server', $MYSQL_HOST, 'root', 'root');
+      $_SESSION['db']['server'][$MYSQL_HOST]['root'][''] = true;
+    }
 
-    set_password('server', 'mariadb_10', 'root', 'root');
-
-    set_password('pgsql', 'pgsql_9', 'postgres', 'root');
-    set_password('pgsql', 'pgsql_10', 'postgres', 'root');
-    set_password('pgsql', 'pgsql_11', 'postgres', 'root');
-    set_password('pgsql', 'pgsql_12', 'postgres', 'root');
-    set_password('pgsql', 'pgsql_13', 'postgres', 'root');
-    set_password('pgsql', 'pgsql_14', 'postgres', 'root');
-    set_password('pgsql', 'pgsql_15', 'postgres', 'root');
-    set_password('pgsql', 'pgsql_16', 'postgres', 'root');
-    set_password('pgsql', 'pgsql_17', 'postgres', 'root');
+    foreach (self::POSTGRESQL_HOSTS as $POSTGRESQL_HOST) {
+      \Adminer\set_password('pgsql', $POSTGRESQL_HOST, 'postgres', 'root');
+      $_SESSION['db']['pgsql'][$POSTGRESQL_HOST]['postgres'][''] = true;
+    }
   }
 }


### PR DESCRIPTION
Adminer now stores information about databases in $_SESSION and expects it to be set when loading databases' list

https://www.wrike.com/open.htm?id=1667418740