### PR TITLE
fix(setup): use storage directory variable

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -17,7 +17,7 @@ fi
 
 sudo mkdir -p $CERTIFICATES_STORAGE_DIRECTORY
 
-sudo docker compose cp proxy:/data/caddy/pki/authorities/local/root.crt /usr/local/share/ca-certificates/ 2>/dev/null
+sudo docker compose cp proxy:/data/caddy/pki/authorities/local/root.crt $CADDY_ROOT_CERTIFICATE_FILE 2>/dev/null
 
 if [ "$(uname -s)" != "Darwin" ]; then
   docker compose exec proxy wget -qO- --post-data='"0.0.0.0:2019"' --header='Content-Type:application/json' 'http://127.0.0.1:2019/config/admin/listen'
@@ -26,8 +26,8 @@ if [ "$(uname -s)" != "Darwin" ]; then
 
   /tmp/caddy trust
 else
-  sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /usr/local/share/ca-certificates/Le_Phare_Docker_stack_Caddy_root.crt
+  sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain $CADDY_ROOT_CERTIFICATE_FILE
 fi
 
 echo "Certificats Caddy installés avec succès !"
-echo "En cas de problèmes de certificats HTTPS non reconnus (dans votre navigateur par ex.), importez le fichier suivant dans les certificats du logiciel : /usr/local/share/ca-certificates/Le_Phare_Docker_stack_Caddy_root.crt"
+echo "En cas de problèmes de certificats HTTPS non reconnus (dans votre navigateur par ex.), importez le fichier suivant dans les certificats du logiciel : $CADDY_ROOT_CERTIFICATE_FILE"


### PR DESCRIPTION
This allows overriding the default directory by changing `CERTIFICATES_STORAGE_DIRECTORY` (useful for systems with immutable `/usr`).