### PR TITLE
feat: add RabbitMQ 4.1

### DIFF
--- a/rabbitmq/4.yml
+++ b/rabbitmq/4.yml
@@ -1,0 +1,21 @@
+services:
+  rabbitmq_4:
+    image: rabbitmq:4.1-management # RabbitMQ 4.x parle AMQP 0.9.1 (compatible ext-amqp / mvo2-api)
+    hostname: rabbitmq_4 # hostname distinct de v3 (`rabbitmq`) pour éviter l'ambiguïté DNS sur dev_private
+    restart: unless-stopped
+    networks:
+      - private
+    volumes:
+      - rabbitmq_4:/var/lib/rabbitmq
+    environment:
+      VIRTUAL_HOST: rabbitmq4.${DOCKER_HOST_SUFFIX:-local}
+      VIRTUAL_PORT: 15672
+    labels:
+      caddy: rabbitmq4.${DOCKER_HOST_SUFFIX:-local}
+      caddy.tls: internal
+      caddy.reverse_proxy: '{{ upstreams 15672 }}'
+    ports:
+      - 8084:15672 # UI mgmt v4 (v3 = 8083). Visit https://rabbitmq4.${DOCKER_HOST_SUFFIX}:8084 (guest / guest)
+
+volumes:
+  rabbitmq_4:

--- a/rabbitmq/4.yml
+++ b/rabbitmq/4.yml
@@ -1,7 +1,7 @@
 services:
   rabbitmq_4:
-    image: rabbitmq:4.1-management # RabbitMQ 4.x parle AMQP 0.9.1 (compatible ext-amqp / mvo2-api)
-    hostname: rabbitmq_4 # hostname distinct de v3 (`rabbitmq`) pour éviter l'ambiguïté DNS sur dev_private
+    image: rabbitmq:4.1-management
+    hostname: rabbitmq_4
     restart: unless-stopped
     networks:
       - private
@@ -15,7 +15,7 @@ services:
       caddy.tls: internal
       caddy.reverse_proxy: '{{ upstreams 15672 }}'
     ports:
-      - 8084:15672 # UI mgmt v4 (v3 = 8083). Visit https://rabbitmq4.${DOCKER_HOST_SUFFIX}:8084 (guest / guest)
+      - "8084:15672" # UI mgmt v4 (v3 = 8083). Visit https://rabbitmq4.${DOCKER_HOST_SUFFIX}:8084 (guest / guest)
 
 volumes:
   rabbitmq_4:


### PR DESCRIPTION
## Contexte

Ajoute le broker socle **RabbitMQ v4** à la docker-stack partagée, en coexistence avec v3, conformément à la topologie locale (dev).


## Changement

Nouveau fragment `rabbitmq/4.yml` (service `rabbitmq_4`), à sélectionner via `COMPOSE_FILE` — même mécanisme que `rabbitmq/3_10.yml` :

- image `rabbitmq:4.1-management` (**AMQP 0.9.1**, compatible `ext-amqp`)
- **coexistant avec v3 sans conflit** : service / hostname / volume distincts (`rabbitmq_4`)
- UI management sur **`:8084`** (v3 = `:8083`), vhost caddy `rabbitmq4.local`, réseau `private`
- en dev **pas de TLS** : les apps joignent `rabbitmq_4:5672` en `amqp://` clair

## Vérification

Démarré en local (`docker compose ... up -d rabbitmq_4`) :
- RabbitMQ **4.1.8**, node `rabbit@rabbitmq_4`
- listener AMQP 0.9.1 sur `5672`, UI sur `8084`
- v3 (`rabbitmq_3_10`) toujours up en parallèle



🤖 Generated with [Claude Code](https://claude.com/claude-code)